### PR TITLE
add conditional import for tensorflow

### DIFF
--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -8,8 +8,8 @@ import matplotlib.pyplot as plt
 import multiprocessing
 import numpy as np
 # import zipfile
-
-from antspynet.utilities import brain_extraction
+if os.environ.get("BRAIN_MASKING") == "cpu":
+    from antspynet.utilities import brain_extraction
 from .deepmask import *
 from .helpers import *
 from matplotlib.backends.backend_pdf import PdfPages


### PR DESCRIPTION
- relevant to NOEL-MNI/deepFCD/issues/16
- only import the `brain_extraction` module (requires ANTsPyNet/TensorFlow) when environment variable `BRAIN_MASKING=cpu` is set