### PR TITLE
feature: extend integration testing to py38+

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,6 +26,13 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        prune-cache: false
+        cache-suffix: "py${{ matrix.python-version }}"
+        cache-dependency-glob: |
+          **/uv.lock
+          **/pyproject.toml
 
     - name: Install dependencies
       run: |
@@ -87,6 +94,13 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        prune-cache: false
+        cache-suffix: "py${{ matrix.python-version }}"
+        cache-dependency-glob: |
+          **/uv.lock
+          **/pyproject.toml
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,9 @@ jobs:
   run-inference:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:
     - uses: actions/checkout@v4
@@ -26,7 +29,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --python 3.8 --dev --extra cpu
+        uv sync --python ${{ matrix.python-version }} --dev --extra cpu
 
     - name: Download test data
       run: |
@@ -65,7 +68,7 @@ jobs:
     - name: Upload inference outputs
       uses: actions/upload-artifact@v4
       with:
-        name: inference-outputs
+        name: inference-outputs-py${{ matrix.python-version }}
         path: test_output/
         retention-days: 1
 
@@ -73,6 +76,9 @@ jobs:
     needs: run-inference
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:
     - uses: actions/checkout@v4
@@ -84,12 +90,12 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --python 3.8 --dev --extra cpu
+        uv sync --python ${{ matrix.python-version }} --dev --extra cpu
 
     - name: Download inference outputs
       uses: actions/download-artifact@v4
       with:
-        name: inference-outputs
+        name: inference-outputs-py${{ matrix.python-version }}
         path: test_output/
 
     - name: Run integration tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-15]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:
     - uses: actions/checkout@v4
@@ -22,17 +21,14 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Install build dependencies
       run: |
         uv sync --dev --extra cpu
-        uv pip install --system build twine
 
     - name: Build package
       run: |
-        python -m build
+        uv build
 
     - name: Check distribution
       run: |


### PR DESCRIPTION
This pull request updates the integration test GitHub Actions workflow to run both inference and integration tests across multiple Python versions, improving test coverage and reliability for different environments. The changes ensure dependencies are installed and artifacts are managed per Python version.

**Multi-Python version support:**

* Added a matrix strategy to both the `run-inference` and `run-integration-tests` jobs to run them on Python 3.8, 3.9, 3.10, and 3.11. [[1]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R18-R20) [[2]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L68-R81)
* Updated dependency installation commands to use the current matrix Python version instead of a hardcoded version. [[1]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L29-R32) [[2]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L87-R98)

**Artifact management:**

* Changed artifact upload and download steps to use Python-version-specific names, preventing conflicts and ensuring the correct outputs are used for each environment. [[1]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L68-R81) [[2]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593L87-R98)